### PR TITLE
Enhance export process and error logging

### DIFF
--- a/CyberRadio.Code/RadioExt-Helper.csproj
+++ b/CyberRadio.Code/RadioExt-Helper.csproj
@@ -11,9 +11,9 @@
         <ApplicationIcon>resources\cyber-radio-assistant.ico</ApplicationIcon>
         <StartupObject>RadioExt_Helper.Program</StartupObject>
         <GenerateDocumentationFile>False</GenerateDocumentationFile>
-        <AssemblyVersion>2.0.51.0</AssemblyVersion>
-        <FileVersion>2.0.51.0</FileVersion>
-        <Version>2.0.51</Version>
+        <AssemblyVersion>2.0.53.0</AssemblyVersion>
+        <FileVersion>2.0.53.0</FileVersion>
+        <Version>2.0.53</Version>
         <Company>Ethan Hann</Company>
         <Product>Cyber Radio Assistant</Product>
         <NeutralLanguage>en</NeutralLanguage>


### PR DESCRIPTION
- Updated `RadioExt-Helper.csproj` version to `2.0.53.0`, including `AssemblyVersion`, `FileVersion`, and `Version` tag.
- Added `_validAudioExtensions` HashSet in `ExportWindow` for validating audio file formats.
- Implemented directory mapping for song files to maintain association with station directories.
- Added functionality to copy song files to new station directories with validation checks.
- Enhanced error logging for better troubleshooting during the export process.
- Modified station directory creation and JSON file generation to use `TrackableObject<Station>`.
- Refined removal of deleted station directories for improved efficiency and accuracy.

Closes #29 