### PR TITLE
Update title bar when lbStations list is empty

### DIFF
--- a/CyberRadio.Code/forms/MainForm.cs
+++ b/CyberRadio.Code/forms/MainForm.cs
@@ -748,6 +748,9 @@ public sealed partial class MainForm : Form
         StationManager.Instance.RemoveStation(station.Id);
         UpdateEnabledStationCount();
         HandleUserControlVisibility();
+
+        if (lbStations.Items.Count <= 0)
+            UpdateTitleBar(null);
     }
 
     private void CmbLanguageSelect_SelectedIndexChanged(object? sender, EventArgs e)


### PR DESCRIPTION
Added a check to see if the `lbStations` list box has zero or fewer items after removing a station. If the list box is empty, the `UpdateTitleBar` method is called with `null` as the argument to ensure the title bar is updated appropriately.

Closes #57 