### PR TITLE
Improve station refresh logic in menu item click handler

### DIFF
--- a/CyberRadio.Code/forms/MainForm.cs
+++ b/CyberRadio.Code/forms/MainForm.cs
@@ -902,12 +902,17 @@ public sealed partial class MainForm : Form
 
     private void RefreshStationsToolStripMenuItem_Click(object sender, EventArgs e)
     {
-        if (lbStations.Items.Count <= 0) return;
-
-        var text = Strings.ConfirmRefreshStations;
-        var caption = Strings.Confirm;
-        if (MessageBox.Show(this, text, caption, MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.Yes)
+        if (lbStations.Items.Count <= 0)
+        {
             PopulateStations();
+        }
+        else
+        {
+            var text = Strings.ConfirmRefreshStations;
+            var caption = Strings.Confirm;
+            if (MessageBox.Show(this, text, caption, MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.Yes)
+                PopulateStations();
+        }
     }
 
     private void SynchronizeStationsToolStripMenuItem_Click(object sender, EventArgs e)


### PR DESCRIPTION
Modified `RefreshStationsToolStripMenuItem_Click` to always call `PopulateStations()`. If `lbStations` is empty, it directly calls `PopulateStations()`. If not, it prompts the user with a confirmation dialog before proceeding. This ensures stations are populated regardless of the initial state of `lbStations`.

Closes #58 