### PR TITLE
Update dependencies, add localization, and enhance icon handling

### DIFF
--- a/CyberRadio.Code/RadioExt-Helper.csproj
+++ b/CyberRadio.Code/RadioExt-Helper.csproj
@@ -78,7 +78,7 @@
         <PackageReference Include="System.Text.Json" Version="8.0.5" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
         <PackageReference Include="TagLibSharp" Version="2.3.0" />
-        <PackageReference Include="WIG.Lib" Version="1.0.44" />
+        <PackageReference Include="WIG.Lib" Version="1.0.45" />
     </ItemGroup>
 
     <ItemGroup>

--- a/CyberRadio.Code/Strings.Designer.cs
+++ b/CyberRadio.Code/Strings.Designer.cs
@@ -2039,6 +2039,24 @@ namespace RadioExt_Helper {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No stations were imported. Verify the .zip/.rar file contains a valid station..
+        /// </summary>
+        internal static string MainForm_NoStationsImported {
+            get {
+                return ResourceManager.GetString("MainForm_NoStationsImported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Nothing to Import.
+        /// </summary>
+        internal static string MainForm_NoStationsImportedTitle {
+            get {
+                return ResourceManager.GetString("MainForm_NoStationsImportedTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Backup Files (*.zip).
         /// </summary>
         internal static string MainForm_RestoreFileBrowserFilter {

--- a/CyberRadio.Code/Strings.de.resx
+++ b/CyberRadio.Code/Strings.de.resx
@@ -1257,4 +1257,10 @@ Sind Sie sicher, dass Sie alle Stationsdaten löschen möchten?</value>
   <data name="CopySongFilesToBackupHelp" xml:space="preserve">
     <value>Wenn Sie überprüft werden, gibt an, dass Songdateien (einschließlich externer) in der Backup .zip -Datei für die Stationen aufgenommen werden sollten.</value>
   </data>
+  <data name="MainForm_NoStationsImported" xml:space="preserve">
+    <value>Es wurden keine Stationen importiert. Überprüfen Sie, ob die Datei .zip/.rar eine gültige Station enthält.</value>
+  </data>
+  <data name="MainForm_NoStationsImportedTitle" xml:space="preserve">
+    <value>Nichts zu importieren</value>
+  </data>
 </root>

--- a/CyberRadio.Code/Strings.es.resx
+++ b/CyberRadio.Code/Strings.es.resx
@@ -1257,4 +1257,10 @@ Asegúrese de crear una copia de seguridad de sus estaciones antes de borrar los
   <data name="LocateAllMissingSongsDesc" xml:space="preserve">
     <value>Seleccione la carpeta que contiene los archivos de canciones faltantes</value>
   </data>
+  <data name="MainForm_NoStationsImported" xml:space="preserve">
+    <value>No se importaron estaciones. Verifique que el archivo .zip/.Rar contiene una estación válida.</value>
+  </data>
+  <data name="MainForm_NoStationsImportedTitle" xml:space="preserve">
+    <value>Nada para importar</value>
+  </data>
 </root>

--- a/CyberRadio.Code/Strings.fr.resx
+++ b/CyberRadio.Code/Strings.fr.resx
@@ -1257,4 +1257,10 @@ Assurez-vous de créer une sauvegarde de vos stations avant de nettoyer les donn
   <data name="CopySongFilesToBackupHelp" xml:space="preserve">
     <value>S'il est vérifié, indique que les fichiers de chansons (y compris externes) doivent être inclus dans le fichier de sauvegarde .zip pour les stations.</value>
   </data>
+  <data name="MainForm_NoStationsImported" xml:space="preserve">
+    <value>Aucune station n'a été importée. Vérifiez que le fichier .zip / .rar contient une station valide.</value>
+  </data>
+  <data name="MainForm_NoStationsImportedTitle" xml:space="preserve">
+    <value>Rien à importer</value>
+  </data>
 </root>

--- a/CyberRadio.Code/Strings.it.resx
+++ b/CyberRadio.Code/Strings.it.resx
@@ -1257,4 +1257,10 @@ Sei sicuro di voler cancellare tutti i dati della stazione?</value>
   <data name="CopySongFilesToBackupHelp" xml:space="preserve">
     <value>Se verificati, indica che i file di brani (incluso esterno) dovrebbero essere inclusi nel file .zip di backup per le stazioni.</value>
   </data>
+  <data name="MainForm_NoStationsImported" xml:space="preserve">
+    <value>Nessuna stazione è stata importata. Verificare il file .zip/.rar contiene una stazione valida.</value>
+  </data>
+  <data name="MainForm_NoStationsImportedTitle" xml:space="preserve">
+    <value>Niente da importare</value>
+  </data>
 </root>

--- a/CyberRadio.Code/Strings.pt.resx
+++ b/CyberRadio.Code/Strings.pt.resx
@@ -1257,4 +1257,10 @@ Tem certeza de que deseja limpar todos os dados da estação?</value>
   <data name="CopySongFilesToBackupHelp" xml:space="preserve">
     <value>Se verificado, indica que os arquivos de músicas (incluindo externos) devem ser incluídos no arquivo .zip de backup para as estações.</value>
   </data>
+  <data name="MainForm_NoStationsImported" xml:space="preserve">
+    <value>Nenhuma posição foi importada. Verifique se o arquivo .zip/.ru contém uma estação válida.</value>
+  </data>
+  <data name="MainForm_NoStationsImportedTitle" xml:space="preserve">
+    <value>Nada para importar</value>
+  </data>
 </root>

--- a/CyberRadio.Code/Strings.resx
+++ b/CyberRadio.Code/Strings.resx
@@ -1257,4 +1257,10 @@ Are you sure you want to clear all station data?</value>
   <data name="LocateAllMissingSongsDesc" xml:space="preserve">
     <value>Select the folder containing the missing song files</value>
   </data>
+  <data name="MainForm_NoStationsImported" xml:space="preserve">
+    <value>No stations were imported. Verify the .zip/.rar file contains a valid station.</value>
+  </data>
+  <data name="MainForm_NoStationsImportedTitle" xml:space="preserve">
+    <value>Nothing to Import</value>
+  </data>
 </root>

--- a/CyberRadio.Code/Strings.ru.resx
+++ b/CyberRadio.Code/Strings.ru.resx
@@ -1257,4 +1257,10 @@
   <data name="LocateAllMissingSongsDesc" xml:space="preserve">
     <value>Выберите папку, содержащую отсутствующие файлы песни</value>
   </data>
+  <data name="MainForm_NoStationsImported" xml:space="preserve">
+    <value>Станции не были импортированы. Проверьте файл .zip/.rar содержит действительную станцию.</value>
+  </data>
+  <data name="MainForm_NoStationsImportedTitle" xml:space="preserve">
+    <value>Ничего, чтобы импортировать</value>
+  </data>
 </root>

--- a/CyberRadio.Code/Strings.zh.resx
+++ b/CyberRadio.Code/Strings.zh.resx
@@ -1257,4 +1257,10 @@
   <data name="CopySongFilesToBackupHelp" xml:space="preserve">
     <value>如果已检查，则指示应将歌曲文件（包括外部）包含在电台的备份.zip文件中。</value>
   </data>
+  <data name="MainForm_NoStationsImported" xml:space="preserve">
+    <value>没有进口车站。验证.zip/.rar文件包含一个有效的站。</value>
+  </data>
+  <data name="MainForm_NoStationsImportedTitle" xml:space="preserve">
+    <value>没什么可进口的</value>
+  </data>
 </root>

--- a/CyberRadio.Code/forms/MainForm.cs
+++ b/CyberRadio.Code/forms/MainForm.cs
@@ -114,6 +114,13 @@ public sealed partial class MainForm : Form
 
     private void OnStationImported(object? sender, List<Guid?> stationIds)
     {
+        if (stationIds.Count <= 0) //No stations were imported, so we can show the user an error message.
+        {
+            MessageBox.Show(Strings.MainForm_NoStationsImported, Strings.MainForm_NoStationsImportedTitle,
+                MessageBoxButtons.OK, MessageBoxIcon.Error);
+            return;
+        } 
+
         var importedIconNames = string.Join(", ", stationIds.Select(stationId =>
             StationManager.Instance.GetStation(stationId)?.Key.TrackedObject.MetaData.DisplayName));
 

--- a/CyberRadio.Code/user_controls/IconEditor.cs
+++ b/CyberRadio.Code/user_controls/IconEditor.cs
@@ -120,10 +120,24 @@ public sealed partial class IconEditor : UserControl, IEditor
     /// </summary>
     public event EventHandler<TrackableObject<WolvenIcon>>? IconUpdated;
 
+    /// <summary>
+    /// Event that occurs when an icon import has started.
+    /// </summary>
     public event EventHandler? IconImportStarted;
+    
+    /// <summary>
+    /// Event that occurs when an icon import has finished.
+    /// </summary>
     public event EventHandler? IconImportFinished;
 
+    /// <summary>
+    /// Event that occurs when an icon extraction has started.
+    /// </summary>
     public event EventHandler? IconExtractStarted;
+
+    /// <summary>
+    /// Event that occurs when an icon extraction has finished.
+    /// </summary>
     public event EventHandler? IconExtractFinished;
 
     ~IconEditor()
@@ -164,7 +178,7 @@ public sealed partial class IconEditor : UserControl, IEditor
             picStationIcon.AllowDrop = false;
             btnImportIcon.Visible = false;
             btnStartExtract.Enabled = true;
-            SetImagePreviewProperties(Icon.TrackedObject.IsFromArchive);
+            SetImagePreviewProperties(true);
         }
         else
         {
@@ -201,16 +215,22 @@ public sealed partial class IconEditor : UserControl, IEditor
                 {
                     txtAtlasName.Enabled = false;
 
-                    txtAtlasName.Text =
-                        !Icon.TrackedObject.CustomIcon.InkAtlasPath.Equals("path\\to\\custom\\atlas.inkatlas")
-                            ? Icon.TrackedObject.AtlasName
-                            : string.Empty;
-                    txtAtlasName.PlaceholderText =
-                        Strings.IconEditor_SetFieldsBasedOnImagePath_To_be_determined_from_archive___;
+                    if (Path.Exists(Icon.TrackedObject.ImagePath))
+                    {
+                        txtAtlasName.Text = Icon.TrackedObject.AtlasName;
+                    }
+                    else
+                    {
+                        txtAtlasName.Text = string.Empty;
+                        txtAtlasName.PlaceholderText = Strings.IconEditor_SetFieldsBasedOnImagePath_To_be_determined_from_archive___;
+                        lblImageStatus.Text = Strings.IconEditor_SetFieldsBasedOnImagePath_The_extracted_image_could_not_be_found_;
+                    }
 
-                    btnStartExtract.Enabled =
-                        !Icon.TrackedObject
-                            .CheckIconValid(); //Disable the extract button if the icon is valid (no need to extract again).
+                    // We only want to disable the import/extract button if the icon is already created. No need to extract again.
+                    btnImportIcon.Enabled = Icon.TrackedObject.IsFromArchive
+                        ? !Path.Exists(Icon.TrackedObject.ImagePath)
+                        : !Path.Exists(Icon.TrackedObject.ArchivePath);
+                    btnStartExtract.Enabled = btnImportIcon.Enabled;
                 }
             });
         }
@@ -512,23 +532,42 @@ public sealed partial class IconEditor : UserControl, IEditor
             picStationIcon.ClearImage();
 
             //If the icon is valid, prevent changes to the fields, and set fromInitialArchive to false (indicating the icon is valid) so the image gets set.
-            if (Icon.TrackedObject.CheckIconValid())
-            {
-                fromInitialArchive = false;
-                MakeEditorReadOnly();
-            }
-            else
-            {
-                UnmakeEditorReadOnly();
-            }
+            //if (Icon.TrackedObject.CheckIconValid())
+            //{
+            //    fromInitialArchive = false;
+            //    MakeEditorReadOnly();
+            //}
+            //else
+            //{
+            //    UnmakeEditorReadOnly();
+            //}
 
             if (fromInitialArchive)
             {
-                lblImageWidth.Text = string.Format(Strings.IconEditor_Translate_W___0_, "TBD");
-                lblImageHeight.Text = string.Format(Strings.IconEditor_Translate_H___0_, "TBD");
-                lblImageFormat.Text = string.Format(Strings.IconEditor_Translate_Format___0_, "TBD");
-                lblImageColorMode.Text = string.Format(Strings.IconEditor_Translate_Color_Mode___0_, "TBD");
-                picStationIcon.Image = Resources.pending_extraction_128x128;
+                if (!Path.Exists(Icon.TrackedObject.ImagePath))
+                {
+                    lblImageWidth.Text = string.Format(Strings.IconEditor_Translate_W___0_, "TBD");
+                    lblImageHeight.Text = string.Format(Strings.IconEditor_Translate_H___0_, "TBD");
+                    lblImageFormat.Text = string.Format(Strings.IconEditor_Translate_Format___0_, "TBD");
+                    lblImageColorMode.Text = string.Format(Strings.IconEditor_Translate_Color_Mode___0_, "TBD");
+                    picStationIcon.Image = Resources.pending_extraction_128x128;
+                    UnmakeEditorReadOnly();
+                }
+                else
+                {
+                    Icon.TrackedObject.EnsureImage();
+                    picStationIcon.SetImage(Icon.TrackedObject.ImagePath);
+
+                    lblImageWidth.Text = string.Format(Strings.IconEditor_Translate_W___0_,
+                        picStationIcon.ImageProperties.Width + " px");
+                    lblImageHeight.Text = string.Format(Strings.IconEditor_Translate_H___0_,
+                        picStationIcon.ImageProperties.Height + " px");
+                    lblImageFormat.Text = string.Format(Strings.IconEditor_Translate_Format___0_,
+                        picStationIcon.ImageProperties.ImageFormat);
+                    lblImageColorMode.Text = string.Format(Strings.IconEditor_Translate_Color_Mode___0_,
+                        picStationIcon.ImageProperties.PixelFormat);
+                    MakeEditorReadOnly();
+                }
             }
             else
             {
@@ -543,6 +582,10 @@ public sealed partial class IconEditor : UserControl, IEditor
                     picStationIcon.ImageProperties.ImageFormat);
                 lblImageColorMode.Text = string.Format(Strings.IconEditor_Translate_Color_Mode___0_,
                     picStationIcon.ImageProperties.PixelFormat);
+                if (Icon.TrackedObject.CheckIconValid())
+                    MakeEditorReadOnly();
+                else
+                    UnmakeEditorReadOnly();
             }
 
             if (picStationIcon.Image == null) return;
@@ -575,7 +618,12 @@ public sealed partial class IconEditor : UserControl, IEditor
             txtImagePath.ReadOnly = true;
             txtIconPath.ReadOnly = true;
             txtIconPart.ReadOnly = true;
-            btnImportIcon.Enabled = false;
+
+            // We only want to disable the import/extract button if the icon is already created.
+            btnImportIcon.Enabled = Icon.TrackedObject.IsFromArchive
+                ? !Path.Exists(Icon.TrackedObject.ImagePath)
+                : !Path.Exists(Icon.TrackedObject.ArchivePath);
+
             btnCancelImport.Enabled = _isImporting || _isExtracting;
             picStationIcon.AllowDrop = false;
 


### PR DESCRIPTION
Updated the `WIG.Lib` package reference in `RadioExt-Helper.csproj` from version `1.0.44` to `1.0.45`.

Added new localized strings for "No stations were imported" and "Nothing to Import" in multiple resource files.

In `MainForm.cs`, added logic to display an error message if no stations were imported.

In `IconEditor.cs`, added events for icon import and extraction processes (`IconImportStarted`, `IconImportFinished`, `IconExtractStarted`, `IconExtractFinished`).

Modified `IconEditor.cs` to handle image preview properties and text fields based on the existence of the image path.

Adjusted the logic in `IconEditor.cs` to enable or disable import/extract buttons based on the icon's validity and existence.

In `StationManager.cs`, added custom icon data to stations and ensured the first icon is set as active if no archive files are present.

Introduced a list of custom data keys in `StationManager.cs` for managing icon-related metadata.

Closes #59 