### PR TITLE
Add forbidden path checks and first run handling

### DIFF
--- a/CyberRadio.Code/Strings.Designer.cs
+++ b/CyberRadio.Code/Strings.Designer.cs
@@ -1118,6 +1118,60 @@ namespace RadioExt_Helper {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The staging path is related to a game or launcher directory and is not allowed..
+        /// </summary>
+        internal static string ForbiddenPath_KeywordMatch {
+            get {
+                return ResourceManager.GetString("ForbiddenPath_KeywordMatch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The staging path cannot be set to the Program Files directory..
+        /// </summary>
+        internal static string ForbiddenPath_ProgramFiles {
+            get {
+                return ResourceManager.GetString("ForbiddenPath_ProgramFiles", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The staging path cannot be set to the root of a drive.
+        /// </summary>
+        internal static string ForbiddenPath_RootDirectory {
+            get {
+                return ResourceManager.GetString("ForbiddenPath_RootDirectory", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The staging path cannot be set to a reserved system directory..
+        /// </summary>
+        internal static string ForbiddenPath_SystemDirectory {
+            get {
+                return ResourceManager.GetString("ForbiddenPath_SystemDirectory", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The staging path cannot be set to an application data directory..
+        /// </summary>
+        internal static string ForbiddenPath_UserAppData {
+            get {
+                return ResourceManager.GetString("ForbiddenPath_UserAppData", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The staging path cannot be set to a Vortex-managed folder..
+        /// </summary>
+        internal static string ForbiddenPath_VortexFolder {
+            get {
+                return ResourceManager.GetString("ForbiddenPath_VortexFolder", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to From .archive file....
         /// </summary>
         internal static string FromArchiveFile {
@@ -2879,6 +2933,15 @@ namespace RadioExt_Helper {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Checking staging path....
+        /// </summary>
+        internal static string SplashScreen_CheckingStagingPath {
+            get {
+                return ResourceManager.GetString("SplashScreen_CheckingStagingPath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Finalizing....
         /// </summary>
         internal static string SplashScreen_Finalizing {
@@ -2915,6 +2978,24 @@ namespace RadioExt_Helper {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Staging path was invalid. Reset to an empty string..
+        /// </summary>
+        internal static string SplashScreen_StagingPathForbidden {
+            get {
+                return ResourceManager.GetString("SplashScreen_StagingPathForbidden", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Staging path is valid!.
+        /// </summary>
+        internal static string SplashScreen_StagingPathValid {
+            get {
+                return ResourceManager.GetString("SplashScreen_StagingPathValid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Starting....
         /// </summary>
         internal static string SplashScreen_Starting {
@@ -2947,6 +3028,15 @@ namespace RadioExt_Helper {
         internal static string StagingPath {
             get {
                 return ResourceManager.GetString("StagingPath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid Path: {0}.
+        /// </summary>
+        internal static string StagingPathForbidden {
+            get {
+                return ResourceManager.GetString("StagingPathForbidden", resourceCulture);
             }
         }
         

--- a/CyberRadio.Code/Strings.de.resx
+++ b/CyberRadio.Code/Strings.de.resx
@@ -1263,4 +1263,34 @@ Sind Sie sicher, dass Sie alle Stationsdaten löschen möchten?</value>
   <data name="MainForm_NoStationsImportedTitle" xml:space="preserve">
     <value>Nichts zu importieren</value>
   </data>
+  <data name="StagingPathForbidden" xml:space="preserve">
+    <value>Ungültiger Pfad: {0}</value>
+  </data>
+  <data name="ForbiddenPath_RootDirectory" xml:space="preserve">
+    <value>Der Staging -Pfad kann nicht auf die Wurzel eines Laufwerks eingestellt werden</value>
+  </data>
+  <data name="ForbiddenPath_SystemDirectory" xml:space="preserve">
+    <value>Der Staging -Pfad kann nicht auf ein reserviertes Systemverzeichnis eingestellt werden.</value>
+  </data>
+  <data name="ForbiddenPath_ProgramFiles" xml:space="preserve">
+    <value>Der Staging -Pfad kann nicht auf das Verzeichnis der Programmdateien eingestellt werden.</value>
+  </data>
+  <data name="ForbiddenPath_UserAppData" xml:space="preserve">
+    <value>Der Staging -Pfad kann nicht auf ein Anwendungsdatenverzeichnis eingestellt werden.</value>
+  </data>
+  <data name="ForbiddenPath_VortexFolder" xml:space="preserve">
+    <value>Der Staging-Pfad kann nicht auf einen wirbelmännischen Ordner eingestellt werden.</value>
+  </data>
+  <data name="ForbiddenPath_KeywordMatch" xml:space="preserve">
+    <value>Der Staging -Pfad hängt mit einem Spiel- oder Launcher -Verzeichnis zusammen und ist nicht zulässig.</value>
+  </data>
+  <data name="SplashScreen_CheckingStagingPath" xml:space="preserve">
+    <value>Überprüfen Sie den Staging -Pfad ...</value>
+  </data>
+  <data name="SplashScreen_StagingPathForbidden" xml:space="preserve">
+    <value>Der Staging -Pfad war ungültig. Auf eine leere Zeichenfolge zurücksetzen.</value>
+  </data>
+  <data name="SplashScreen_StagingPathValid" xml:space="preserve">
+    <value>Der Staging -Pfad ist gültig!</value>
+  </data>
 </root>

--- a/CyberRadio.Code/Strings.es.resx
+++ b/CyberRadio.Code/Strings.es.resx
@@ -1263,4 +1263,34 @@ Asegúrese de crear una copia de seguridad de sus estaciones antes de borrar los
   <data name="MainForm_NoStationsImportedTitle" xml:space="preserve">
     <value>Nada para importar</value>
   </data>
+  <data name="StagingPathForbidden" xml:space="preserve">
+    <value>Ruta no válida: {0}</value>
+  </data>
+  <data name="ForbiddenPath_RootDirectory" xml:space="preserve">
+    <value>La ruta de puesta en escena no se puede establecer en la raíz de una unidad</value>
+  </data>
+  <data name="ForbiddenPath_SystemDirectory" xml:space="preserve">
+    <value>La ruta de puesta en escena no se puede establecer en un directorio de sistema reservado.</value>
+  </data>
+  <data name="ForbiddenPath_ProgramFiles" xml:space="preserve">
+    <value>La ruta de puesta en escena no se puede configurar en el directorio de archivos del programa.</value>
+  </data>
+  <data name="ForbiddenPath_UserAppData" xml:space="preserve">
+    <value>La ruta de puesta en escena no se puede establecer en un directorio de datos de aplicación.</value>
+  </data>
+  <data name="ForbiddenPath_VortexFolder" xml:space="preserve">
+    <value>La ruta de puesta en escena no se puede establecer en una carpeta administrada por vórtice.</value>
+  </data>
+  <data name="ForbiddenPath_KeywordMatch" xml:space="preserve">
+    <value>La ruta de puesta en escena está relacionada con un directorio de juego o lanzador y no está permitido.</value>
+  </data>
+  <data name="SplashScreen_CheckingStagingPath" xml:space="preserve">
+    <value>Verificación de la ruta de puesta en escena ...</value>
+  </data>
+  <data name="SplashScreen_StagingPathForbidden" xml:space="preserve">
+    <value>La ruta de puesta en escena no era válida. Reiniciar a una cadena vacía.</value>
+  </data>
+  <data name="SplashScreen_StagingPathValid" xml:space="preserve">
+    <value>¡La ruta de puesta en escena es válida!</value>
+  </data>
 </root>

--- a/CyberRadio.Code/Strings.fr.resx
+++ b/CyberRadio.Code/Strings.fr.resx
@@ -1263,4 +1263,34 @@ Assurez-vous de créer une sauvegarde de vos stations avant de nettoyer les donn
   <data name="MainForm_NoStationsImportedTitle" xml:space="preserve">
     <value>Rien à importer</value>
   </data>
+  <data name="StagingPathForbidden" xml:space="preserve">
+    <value>Chemin non valide: {0}</value>
+  </data>
+  <data name="ForbiddenPath_RootDirectory" xml:space="preserve">
+    <value>Le chemin de stadification ne peut pas être réglé sur la racine d'un lecteur</value>
+  </data>
+  <data name="ForbiddenPath_SystemDirectory" xml:space="preserve">
+    <value>Le chemin de stadification ne peut pas être défini sur un répertoire système réservé.</value>
+  </data>
+  <data name="ForbiddenPath_ProgramFiles" xml:space="preserve">
+    <value>Le chemin de stadification ne peut pas être défini sur le répertoire des fichiers du programme.</value>
+  </data>
+  <data name="ForbiddenPath_UserAppData" xml:space="preserve">
+    <value>Le chemin de stadification ne peut pas être défini sur un répertoire de données d'application.</value>
+  </data>
+  <data name="ForbiddenPath_VortexFolder" xml:space="preserve">
+    <value>Le chemin de stadification ne peut pas être défini sur un dossier géré par vortex.</value>
+  </data>
+  <data name="ForbiddenPath_KeywordMatch" xml:space="preserve">
+    <value>Le chemin de stadification est lié à un répertoire de jeu ou de lanceur et n'est pas autorisé.</value>
+  </data>
+  <data name="SplashScreen_CheckingStagingPath" xml:space="preserve">
+    <value>Vérification du chemin de stadification ...</value>
+  </data>
+  <data name="SplashScreen_StagingPathForbidden" xml:space="preserve">
+    <value>Le chemin de mise en scène n'était pas valide. Réinitialiser avec une chaîne vide.</value>
+  </data>
+  <data name="SplashScreen_StagingPathValid" xml:space="preserve">
+    <value>Le chemin de mise en scène est valide!</value>
+  </data>
 </root>

--- a/CyberRadio.Code/Strings.it.resx
+++ b/CyberRadio.Code/Strings.it.resx
@@ -1263,4 +1263,34 @@ Sei sicuro di voler cancellare tutti i dati della stazione?</value>
   <data name="MainForm_NoStationsImportedTitle" xml:space="preserve">
     <value>Niente da importare</value>
   </data>
+  <data name="StagingPathForbidden" xml:space="preserve">
+    <value>Path non valido: {0}</value>
+  </data>
+  <data name="ForbiddenPath_RootDirectory" xml:space="preserve">
+    <value>Il percorso di stadiazione non può essere impostato sulla radice di un'unità</value>
+  </data>
+  <data name="ForbiddenPath_SystemDirectory" xml:space="preserve">
+    <value>Il percorso di stadiazione non può essere impostato su una directory di sistema riservata.</value>
+  </data>
+  <data name="ForbiddenPath_ProgramFiles" xml:space="preserve">
+    <value>Il percorso di stadiazione non può essere impostato sulla directory dei file del programma.</value>
+  </data>
+  <data name="ForbiddenPath_UserAppData" xml:space="preserve">
+    <value>Il percorso di stadiazione non può essere impostato su una directory dei dati dell'applicazione.</value>
+  </data>
+  <data name="ForbiddenPath_VortexFolder" xml:space="preserve">
+    <value>Il percorso di staging non può essere impostato su una cartella gestita da vortice.</value>
+  </data>
+  <data name="ForbiddenPath_KeywordMatch" xml:space="preserve">
+    <value>Il percorso di gestione temporanea è correlato a una directory di gioco o lanciatore e non è consentito.</value>
+  </data>
+  <data name="SplashScreen_CheckingStagingPath" xml:space="preserve">
+    <value>Controllo del percorso di stadiazione ...</value>
+  </data>
+  <data name="SplashScreen_StagingPathForbidden" xml:space="preserve">
+    <value>Il percorso di stadiazione non era valido. Ripristina una stringa vuota.</value>
+  </data>
+  <data name="SplashScreen_StagingPathValid" xml:space="preserve">
+    <value>Il percorso di stadiazione è valido!</value>
+  </data>
 </root>

--- a/CyberRadio.Code/Strings.pt.resx
+++ b/CyberRadio.Code/Strings.pt.resx
@@ -1263,4 +1263,34 @@ Tem certeza de que deseja limpar todos os dados da estação?</value>
   <data name="MainForm_NoStationsImportedTitle" xml:space="preserve">
     <value>Nada para importar</value>
   </data>
+  <data name="StagingPathForbidden" xml:space="preserve">
+    <value>Caminho inválido: {0}</value>
+  </data>
+  <data name="ForbiddenPath_RootDirectory" xml:space="preserve">
+    <value>O caminho de estadiamento não pode ser definido para a raiz de uma unidade</value>
+  </data>
+  <data name="ForbiddenPath_SystemDirectory" xml:space="preserve">
+    <value>O caminho de estadiamento não pode ser definido como um diretório de sistema reservado.</value>
+  </data>
+  <data name="ForbiddenPath_ProgramFiles" xml:space="preserve">
+    <value>O caminho de estadiamento não pode ser definido como o diretório de arquivos do programa.</value>
+  </data>
+  <data name="ForbiddenPath_UserAppData" xml:space="preserve">
+    <value>O caminho de estadiamento não pode ser definido como um diretório de dados do aplicativo.</value>
+  </data>
+  <data name="ForbiddenPath_VortexFolder" xml:space="preserve">
+    <value>O caminho de encenação não pode ser definido como uma pasta gerenciada pelo vórtice.</value>
+  </data>
+  <data name="ForbiddenPath_KeywordMatch" xml:space="preserve">
+    <value>O caminho de preparação está relacionado a um diretório de jogo ou lançador e não é permitido.</value>
+  </data>
+  <data name="SplashScreen_CheckingStagingPath" xml:space="preserve">
+    <value>Verificando o caminho de estadiamento ...</value>
+  </data>
+  <data name="SplashScreen_StagingPathForbidden" xml:space="preserve">
+    <value>O caminho de estadiamento foi inválido. Redefinir para uma corda vazia.</value>
+  </data>
+  <data name="SplashScreen_StagingPathValid" xml:space="preserve">
+    <value>O caminho de encenação é válido!</value>
+  </data>
 </root>

--- a/CyberRadio.Code/Strings.resx
+++ b/CyberRadio.Code/Strings.resx
@@ -1263,4 +1263,34 @@ Are you sure you want to clear all station data?</value>
   <data name="MainForm_NoStationsImportedTitle" xml:space="preserve">
     <value>Nothing to Import</value>
   </data>
+  <data name="StagingPathForbidden" xml:space="preserve">
+    <value>Invalid Path: {0}</value>
+  </data>
+  <data name="ForbiddenPath_RootDirectory" xml:space="preserve">
+    <value>The staging path cannot be set to the root of a drive</value>
+  </data>
+  <data name="ForbiddenPath_SystemDirectory" xml:space="preserve">
+    <value>The staging path cannot be set to a reserved system directory.</value>
+  </data>
+  <data name="ForbiddenPath_ProgramFiles" xml:space="preserve">
+    <value>The staging path cannot be set to the Program Files directory.</value>
+  </data>
+  <data name="ForbiddenPath_UserAppData" xml:space="preserve">
+    <value>The staging path cannot be set to an application data directory.</value>
+  </data>
+  <data name="ForbiddenPath_VortexFolder" xml:space="preserve">
+    <value>The staging path cannot be set to a Vortex-managed folder.</value>
+  </data>
+  <data name="ForbiddenPath_KeywordMatch" xml:space="preserve">
+    <value>The staging path is related to a game or launcher directory and is not allowed.</value>
+  </data>
+  <data name="SplashScreen_CheckingStagingPath" xml:space="preserve">
+    <value>Checking staging path...</value>
+  </data>
+  <data name="SplashScreen_StagingPathForbidden" xml:space="preserve">
+    <value>Staging path was invalid. Reset to an empty string.</value>
+  </data>
+  <data name="SplashScreen_StagingPathValid" xml:space="preserve">
+    <value>Staging path is valid!</value>
+  </data>
 </root>

--- a/CyberRadio.Code/Strings.ru.resx
+++ b/CyberRadio.Code/Strings.ru.resx
@@ -1263,4 +1263,34 @@
   <data name="MainForm_NoStationsImportedTitle" xml:space="preserve">
     <value>Ничего, чтобы импортировать</value>
   </data>
+  <data name="StagingPathForbidden" xml:space="preserve">
+    <value>Неверный путь: {0}</value>
+  </data>
+  <data name="ForbiddenPath_RootDirectory" xml:space="preserve">
+    <value>Путь по постановке не может быть установлен на корень диска</value>
+  </data>
+  <data name="ForbiddenPath_SystemDirectory" xml:space="preserve">
+    <value>Путь по постановке не может быть установлен в резервный каталог системы.</value>
+  </data>
+  <data name="ForbiddenPath_ProgramFiles" xml:space="preserve">
+    <value>Путь постановки не может быть установлен в каталог файлов программы.</value>
+  </data>
+  <data name="ForbiddenPath_UserAppData" xml:space="preserve">
+    <value>Путь постановки не может быть установлен в каталог данных приложения.</value>
+  </data>
+  <data name="ForbiddenPath_VortexFolder" xml:space="preserve">
+    <value>Путь к постановке не может быть установлен в папку, управляемую вихрем.</value>
+  </data>
+  <data name="ForbiddenPath_KeywordMatch" xml:space="preserve">
+    <value>Переходный путь связан с каталогом игры или пусковой установки и не допускается.</value>
+  </data>
+  <data name="SplashScreen_CheckingStagingPath" xml:space="preserve">
+    <value>Проверка промежуточного пути ...</value>
+  </data>
+  <data name="SplashScreen_StagingPathForbidden" xml:space="preserve">
+    <value>Поставленный путь был недействительным. Сбросить на пустую строку.</value>
+  </data>
+  <data name="SplashScreen_StagingPathValid" xml:space="preserve">
+    <value>Постановка пути действителен!</value>
+  </data>
 </root>

--- a/CyberRadio.Code/Strings.zh.resx
+++ b/CyberRadio.Code/Strings.zh.resx
@@ -1263,4 +1263,34 @@
   <data name="MainForm_NoStationsImportedTitle" xml:space="preserve">
     <value>没什么可进口的</value>
   </data>
+  <data name="StagingPathForbidden" xml:space="preserve">
+    <value>无效路径：{0}</value>
+  </data>
+  <data name="ForbiddenPath_RootDirectory" xml:space="preserve">
+    <value>无法将登台路径设置为驱动器的根部</value>
+  </data>
+  <data name="ForbiddenPath_SystemDirectory" xml:space="preserve">
+    <value>无法将分期路径设置为保留系统目录。</value>
+  </data>
+  <data name="ForbiddenPath_ProgramFiles" xml:space="preserve">
+    <value>登台路径不能设置为程序文件目录。</value>
+  </data>
+  <data name="ForbiddenPath_UserAppData" xml:space="preserve">
+    <value>登台路径不能设置为应用程序数据目录。</value>
+  </data>
+  <data name="ForbiddenPath_VortexFolder" xml:space="preserve">
+    <value>无法将登台路径设置为涡流管理的文件夹。</value>
+  </data>
+  <data name="ForbiddenPath_KeywordMatch" xml:space="preserve">
+    <value>登台路径与游戏或启动器目录有关，不允许。</value>
+  </data>
+  <data name="SplashScreen_CheckingStagingPath" xml:space="preserve">
+    <value>检查登台路径...</value>
+  </data>
+  <data name="SplashScreen_StagingPathForbidden" xml:space="preserve">
+    <value>分期路径无效。重置为空字符串。</value>
+  </data>
+  <data name="SplashScreen_StagingPathValid" xml:space="preserve">
+    <value>登台路径有效！</value>
+  </data>
 </root>

--- a/CyberRadio.Code/config/ApplicationConfig.cs
+++ b/CyberRadio.Code/config/ApplicationConfig.cs
@@ -35,6 +35,7 @@ public sealed class ApplicationConfig
 {
     // Constants for config keys
     private const string AutoCheckForUpdatesKey = "autoCheckForUpdates";
+    private const string IsFirstRunKey = "isFirstRun";
     private const string AutoExportToGameKey = "autoExportToGame";
     private const string WatchForGameChangesKey = "watchForGameChanges";
     private const string CopySongFilesToBackupKey = "copySongFilesToBackup";
@@ -53,6 +54,12 @@ public sealed class ApplicationConfig
     [Config(AutoCheckForUpdatesKey)]
     [Description("CheckForUpdatesOptionHelp")]
     public bool AutoCheckForUpdates { get; set; } = true;
+
+    /// <summary>
+    /// Specifies whether the application is running for the first time.
+    /// </summary>
+    [Config(IsFirstRunKey)]
+    public bool IsFirstRun { get; set; } = true;
 
     /// <summary>
     ///     Specifies whether the application should automatically export the stations to the game
@@ -76,6 +83,9 @@ public sealed class ApplicationConfig
     [Description("CopySongFilesToBackupHelp")]
     public bool CopySongFilesToBackup { get; set; } = true;
 
+    /// <summary>
+    /// Specifies the default location for song files that have been imported from a station .zip or .rar file.
+    /// </summary>
     [Config(DefaultSongLocationKey)]
     [Description("DefaultSongLocationHelp")]
     public string DefaultSongLocation { get; set; } = Environment.GetFolderPath(Environment.SpecialFolder.MyMusic);

--- a/CyberRadio.Code/models/ForbiddenPathReason.cs
+++ b/CyberRadio.Code/models/ForbiddenPathReason.cs
@@ -1,0 +1,49 @@
+﻿using System.ComponentModel;
+
+namespace RadioExt_Helper.models;
+
+/// <summary>
+/// Defines the various reasons a path may be considered forbidden.
+/// </summary>
+public enum ForbiddenPathReason
+{
+    /// <summary>
+    /// No reason. The path was valid.
+    /// </summary>
+    None,
+    /// <summary>
+    /// The path was a root directory.
+    /// </summary>
+    [Description("ForbiddenPath_RootDirectory")]
+    RootDirectory,
+
+    /// <summary>
+    /// The path was within a system directory.
+    /// </summary>
+    [Description("ForbiddenPath_SystemDirectory")]
+    SystemDirectory,
+
+    /// <summary>
+    /// The path was within the program files directory (either x86 or x64).
+    /// </summary>
+    [Description("ForbiddenPath_ProgramFiles")]
+    ProgramFiles,
+
+    /// <summary>
+    /// The path was within the user's appdata folder (either local or roaming).
+    /// </summary>
+    [Description("ForbiddenPath_UserAppData")]
+    UserAppData,
+
+    /// <summary>
+    /// The path was within Vortex Mod Manager managed folder.
+    /// </summary>
+    [Description("ForbiddenPath_VortexFolder")]
+    VortexFolder,
+
+    /// <summary>
+    /// The path contained forbidden keywords that would make it an invalid path (e.g., steam, epic games, gog galaxy, etc...).
+    /// </summary>
+    [Description("ForbiddenPath_KeywordMatch")]
+    KeywordMatch
+}

--- a/CyberRadio.Code/models/ForbiddenPathResult.cs
+++ b/CyberRadio.Code/models/ForbiddenPathResult.cs
@@ -1,0 +1,17 @@
+﻿namespace RadioExt_Helper.models;
+
+/// <summary>
+/// Represents the result of a forbidden path check.
+/// </summary>
+public class ForbiddenPathResult
+{
+    /// <summary>
+    /// Indicates if the path is forbidden.
+    /// </summary>
+    public bool IsForbidden { get; set; }
+
+    /// <summary>
+    /// The reason the path is considered forbidden. The description of this enum can be used for displaying in message boxes.
+    /// </summary>
+    public ForbiddenPathReason Reason { get; set; }
+}


### PR DESCRIPTION
- Added new localized strings for forbidden paths and splash screen messages in `Strings.Designer.cs`.
- Updated translations in various `Strings.*.resx` files.
- Introduced `IsFirstRunKey` and `IsFirstRun` in `ApplicationConfig.cs`.
- Added `DefaultSongLocation` property in `ApplicationConfig`.
- Updated `PathSettings.cs` to check forbidden paths and display errors.
- Modified `SplashScreen.cs` to validate staging paths and handle song migration.
- Added `IsForbiddenPath` method and supporting helpers in `PathHelper`.
- Created `ForbiddenPathReason` enum and `ForbiddenPathResult` class.

Closes #64 