### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 jobs:
   update-version:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ethan-hann/CyberRadio-Assistant/security/code-scanning/2](https://github.com/ethan-hann/CyberRadio-Assistant/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow to explicitly define the least privileges required. Based on the workflow's functionality:
1. It needs `contents: write` to push changes to the repository.
2. It does not require any other permissions, so all other permissions should be omitted or set to `none`.

The `permissions` block should be added at the root level of the workflow to apply to all jobs. This ensures that the `GITHUB_TOKEN` is restricted to the minimum required permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
