### PR TITLE
Update version to 2.0.447 and adjust path handling

### DIFF
--- a/CyberRadio.Code/RadioExt-Helper.csproj
+++ b/CyberRadio.Code/RadioExt-Helper.csproj
@@ -13,7 +13,7 @@
         <GenerateDocumentationFile>True</GenerateDocumentationFile>
         <AssemblyVersion>2.0.446.0</AssemblyVersion>
         <FileVersion>2.0.446.0</FileVersion>
-        <Version>2.0.446</Version>
+        <Version>2.0.447</Version>
         <Company>Ethan Hann</Company>
         <Product>Cyber Radio Assistant</Product>
         <NeutralLanguage>en</NeutralLanguage>

--- a/CyberRadio.Code/utility/PathHelper.cs
+++ b/CyberRadio.Code/utility/PathHelper.cs
@@ -48,8 +48,7 @@ public static partial class PathHelper
         Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles).ToLowerInvariant(),
         Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86).ToLowerInvariant(),
         Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData).ToLowerInvariant(),
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData).ToLowerInvariant(),
-        Path.GetPathRoot(Environment.SystemDirectory)?.ToLowerInvariant() ?? string.Empty
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData).ToLowerInvariant()
     ];
 
     [GeneratedRegex(@"oo\dext_\d+_win(?:32|64)\.dll", RegexOptions.IgnoreCase, "en-US")]


### PR DESCRIPTION
- Updated version number in `RadioExt-Helper.csproj` from `2.0.446` to `2.0.447`.
- Adjusted path retrieval in `PathHelper.cs` by removing the system drive from the forbidden paths.

Resolves #88 