### PR TITLE
Add LogLayout property to ApplicationConfig class

### DIFF
--- a/CyberRadio.Code/config/ApplicationConfig.cs
+++ b/CyberRadio.Code/config/ApplicationConfig.cs
@@ -148,6 +148,7 @@ public sealed class ApplicationConfig
         LogFileDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             "RadioExt-Helper", "logs"),
         LogHeader = SystemInfo.GetLogFileHeader(),
+        LogLayout = "${longdate}|${level:uppercase=true}|${logger}|${message:withexception=true}",
         IncludeDateTime = true,
         IncludeDateOnly = false
     };


### PR DESCRIPTION
Introduced a new `LogLayout` property in the `ApplicationConfig` class to define the format of log entries. This property includes placeholders for long date, uppercase log level, logger name, and messages with exceptions.

Resolves #90 